### PR TITLE
Missing header for OSX

### DIFF
--- a/dhcptool.c
+++ b/dhcptool.c
@@ -7,6 +7,7 @@
 #include <signal.h>
 #include <sys/time.h>
 #include <time.h>
+#include <netinet/ip.h>
 #include "dhcptool.h"
 #include "dhcp-options.h"
 


### PR DESCRIPTION
Hi.
I tried to compile this on OSX and the compiler complains that `struct ip` is undefined. I included the `netinet/ip.h` header to the list and now it works fine. I guess it won't be breaking Linux/BSD build either.